### PR TITLE
Add collate Option to Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Available options are presented in the table below:
 | `:check`       | Set condition in Honeysql format to create custom CHECK for a column.                         | `false`   | Example: `[:and [:> :month 0] [:<= :month 12]]`                                                                                |
 | `:array`       | Can be added to any field type to make it array.                                              | `false`   | `string?`, examples: `"[]"`, `"[][]"`, `[][10][3]`                                                                             |
 | `:comment`     | Add a comment on the field.                                                                   | `false`   | `string?`                                                                                                                      |
+| `:collate`     | Set collation for text fields.                                                               | `false`   | `string?`, example: `"ko_KR"`                                                                                                  |
 
 
 #### Indexes

--- a/src/automigrate/fields.clj
+++ b/src/automigrate/fields.clj
@@ -322,6 +322,11 @@
   (s/and string? (complement str/blank?)))
 
 
+(s/def ::collate
+  ; Not empty string
+  (s/and string? (complement str/blank?)))
+
+
 (s/def ::options
   (s/keys
     :opt-un [::null
@@ -333,7 +338,8 @@
              ::on-update
              ::check
              ::array
-             ::comment]))
+             ::comment
+             ::collate]))
 
 
 (s/def ::options-strict-keys
@@ -448,6 +454,13 @@
   validate-default-and-type)
 
 
+(s/def ::validate-type-for-collate
+  (fn [{collate :collate
+        column-type :type}]
+    (or (nil? collate)
+      (= (check-type-group column-type) :string))))
+
+
 (s/def ::field-with-type
   (s/merge
     (s/keys
@@ -462,7 +475,8 @@
     ::validate-default-and-null
     ::validate-fk-options-and-null-on-delete
     ::validate-fk-options-and-null-on-update
-    ::validate-default-and-type))
+    ::validate-default-and-type
+    ::validate-type-for-collate))
 
 
 (s/def ::field-name keyword?)

--- a/src/automigrate/sql.clj
+++ b/src/automigrate/sql.clj
@@ -118,7 +118,7 @@
     ::fields/collate
     (s/conformer
       (fn [value]
-        [:raw (format "COLLATE %s" value)]))))
+        [:raw (format "COLLATE \"%s\"" value)]))))
 
 
 (def ^:private options-specs

--- a/src/automigrate/sql.clj
+++ b/src/automigrate/sql.clj
@@ -113,6 +113,14 @@
     (s/conformer identity)))
 
 
+(s/def :automigrate.sql.option->sql/collate
+  (s/and
+    ::fields/collate
+    (s/conformer
+      (fn [value]
+        [:raw (format "COLLATE %s" value)]))))
+
+
 (def ^:private options-specs
   [:automigrate.sql.option->sql/null
    :automigrate.sql.option->sql/primary-key
@@ -123,7 +131,8 @@
    :automigrate.sql.option->sql/on-update
    :automigrate.sql.option->sql/check
    :automigrate.sql.option->sql/array
-   :automigrate.sql.option->sql/comment])
+   :automigrate.sql.option->sql/comment
+   :automigrate.sql.option->sql/collate])
 
 
 (s/def ::->foreign-key-complete
@@ -209,7 +218,8 @@
       (let [rest-options (remove #(= :EMPTY %) [(:on-delete options :EMPTY)
                                                 (:on-update options :EMPTY)
                                                 (:null options :EMPTY)
-                                                (:default options :EMPTY)])]
+                                                (:default options :EMPTY)
+                                                (:collate options :EMPTY)])]
         (conj acc (concat
                     [field-name]
                     (field-type->sql options)

--- a/test/automigrate/fields_test.clj
+++ b/test/automigrate/fields_test.clj
@@ -284,3 +284,12 @@
           (test-util/get-table-schema-from-db
             config/DATABASE-CONN
             "account")))))
+
+(deftest test-validate-collate-ok
+  (testing "check valid collate ok"
+    (is (true? (s/valid? ::fields/validate-type-for-collate {:type :text
+                                                             :collate "ko_KR"}))))
+  
+  (testing "check invalid collate err"
+    (is (false? (s/valid? ::fields/validate-type-for-collate {:type :timestamp
+                                                              :collate "ko_KR"})))))


### PR DESCRIPTION
I added the collate option and implemented a check to ensure that it can only be used with columns of type string.